### PR TITLE
fix: [EBE-118] Add retry handling for connection reset errors in PDV integration

### DIFF
--- a/src/main/java/it/gov/pagopa/idpay/transactions/connector/rest/UserRestClientImpl.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/connector/rest/UserRestClientImpl.java
@@ -55,7 +55,9 @@ public class UserRestClientImpl implements UserRestClient {
                 .map(HttpEntity::getBody)
                 .retryWhen(Retry.fixedDelay(pdvMaxAttempts, Duration.ofMillis(pdvRetryDelay))
                         .filter(ex -> {
-                            boolean retry = (ex instanceof WebClientResponseException.TooManyRequests) || ex.getMessage().startsWith("Connection refused");
+                            boolean retry = (ex instanceof WebClientResponseException.TooManyRequests)
+                                || ex.getMessage().startsWith("Connection refused")
+                                || ex.getMessage().contains("Connection reset by peer");
                             if (retry) {
                                 log.info("[PDV_INTEGRATION] Retrying invocation due to exception: {}: {}", ex.getClass().getSimpleName(), ex.getMessage());
                             }
@@ -89,7 +91,9 @@ public class UserRestClientImpl implements UserRestClient {
                 .map(HttpEntity::getBody)
                 .retryWhen(Retry.fixedDelay(pdvMaxAttempts, Duration.ofMillis(pdvRetryDelay))
                         .filter(ex -> {
-                            boolean retry = (ex instanceof WebClientResponseException.TooManyRequests) || ex.getMessage().startsWith("Connection refused");
+                            boolean retry = (ex instanceof WebClientResponseException.TooManyRequests)
+                                || ex.getMessage().startsWith("Connection refused")
+                                || ex.getMessage().contains("Connection reset by peer");
                             if (retry) {
                                 log.info("[PDV_INTEGRATION] Retrying invocation due to exception: {}: {}", ex.getClass().getSimpleName(), ex.getMessage());
                             }


### PR DESCRIPTION
#### Description
Handled transient Connection reset by peer with retry on PDV calls.

#### List of Changes
Updated retry logic in UserRestClientImpl to handle Connection reset by peer errors.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [ ] Unit
    - [ ] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.