### PR TITLE
feat: [EBE-242] Add authorized amount to PointOfSaleTransactionDTO

### DIFF
--- a/src/main/java/it/gov/pagopa/idpay/transactions/dto/PointOfSaleTransactionDTO.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/dto/PointOfSaleTransactionDTO.java
@@ -20,6 +20,7 @@ public class PointOfSaleTransactionDTO {
   String fiscalCode;
   Long effectiveAmountCents;
   Long rewardAmountCents;
+  Long authorizedAmountCents;
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   LocalDateTime trxDate;
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/it/gov/pagopa/idpay/transactions/dto/mapper/PointOfSaleTransactionMapper.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/dto/mapper/PointOfSaleTransactionMapper.java
@@ -18,10 +18,22 @@ public class PointOfSaleTransactionMapper {
   }
 
   public Mono<PointOfSaleTransactionDTO> toDTO(RewardTransaction trx, String initiativeId, String fiscalCode) {
+
+    Long totalAmount = trx.getAmountCents();
+
+    Long rewardAmount = 0L;
+
+    if (trx.getRewards() != null && trx.getRewards().get(initiativeId) != null) {
+      rewardAmount = Math.abs(trx.getRewards().get(initiativeId).getAccruedRewardCents());
+    }
+
+    Long authorizedAmount = totalAmount - rewardAmount;
+
     PointOfSaleTransactionDTO dto = PointOfSaleTransactionDTO.builder()
         .trxId(trx.getId())
         .effectiveAmountCents(trx.getAmountCents())
-        .rewardAmountCents(trx.getRewards().get(initiativeId).getAccruedRewardCents())
+        .rewardAmountCents(rewardAmount)
+        .authorizedAmountCents(authorizedAmount)
         .trxDate(trx.getTrxDate())
         .elaborationDateTime(trx.getElaborationDateTime())
         .status(trx.getStatus())


### PR DESCRIPTION
#### Description
Added authorizedAmountCents field in PointOfSaleTransactionDTO to handle the authorized amount.

#### List of Changes
Added authorizedAmountCents field in PointOfSaleTransactionDTO.
Updated PointOfSaleTransactionMapper to:
 - Correctly calculate the authorized amount as totalAmount - rewardAmount.
 - Fix the discount calculation (avoiding negative values).
 
Added unit tests.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [x] Unit
    - [x] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [x] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.