### PR TITLE
chore: invoice and membership mutation ports

### DIFF
--- a/src/main/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapter.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapter.java
@@ -1,0 +1,147 @@
+package it.gov.pagopa.idpay.transactions.persistence.mongo;
+
+import it.gov.pagopa.idpay.transactions.dto.batch.BatchCountersDTO;
+import it.gov.pagopa.idpay.transactions.enums.RewardBatchTrxStatus;
+import it.gov.pagopa.idpay.transactions.enums.SyncTrxStatus;
+import it.gov.pagopa.idpay.transactions.model.Reward;
+import it.gov.pagopa.idpay.transactions.model.RewardBatch;
+import it.gov.pagopa.idpay.transactions.model.RewardTransaction;
+import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchTransactionMutationPort;
+import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
+import it.gov.pagopa.idpay.transactions.repository.RewardTransactionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class MongoRewardBatchTransactionMutationAdapter implements RewardBatchTransactionMutationPort {
+
+    private final RewardTransactionRepository rewardTransactionRepository;
+    private final RewardBatchRepository rewardBatchRepository;
+
+    @Override
+    public Mono<RewardTransaction> persistInvoiceUpdate(RewardTransaction transaction) {
+        return rewardTransactionRepository.save(transaction);
+    }
+
+    @Override
+    public Mono<RewardTransaction> moveUpdatedInvoice(
+            RewardTransaction transaction,
+            RewardBatch sourceBatch,
+            RewardBatch targetBatch,
+            BatchCountersDTO sourceCounters,
+            BatchCountersDTO targetCounters
+    ) {
+        return rewardTransactionRepository.save(transaction)
+                .then(rewardBatchRepository.updateTotals(
+                        sourceBatch.getInitiativeId(),
+                        sourceBatch.getId(),
+                        sourceCounters
+                ))
+                .then(rewardBatchRepository.updateTotals(
+                        targetBatch.getInitiativeId(),
+                        targetBatch.getId(),
+                        targetCounters
+                ))
+                .thenReturn(transaction);
+    }
+
+    @Override
+    public Mono<Void> reverseInvoice(
+            RewardTransaction transaction,
+            String initiativeId,
+            String sourceBatchId,
+            BatchCountersDTO counters
+    ) {
+        return rewardTransactionRepository.save(transaction)
+                .then(sourceBatchId == null
+                        ? Mono.empty()
+                        : rewardBatchRepository.updateTotals(initiativeId, sourceBatchId, counters))
+                .then();
+    }
+
+    @Override
+    public Mono<Void> reassignSuspendedTransactions(
+            RewardBatch sourceBatch,
+            RewardBatch targetBatch,
+            String initiativeId,
+            String sourceMonth
+    ) {
+        return rewardTransactionRepository
+                .findByFilter(sourceBatch.getId(), initiativeId, List.of(RewardBatchTrxStatus.SUSPENDED))
+                .concatMap(transaction -> {
+                    transaction.setRewardBatchId(targetBatch.getId());
+                    transaction.setStatus(SyncTrxStatus.INVOICED.name());
+                    if (transaction.getRewardBatchLastMonthElaborated() == null) {
+                        transaction.setRewardBatchLastMonthElaborated(sourceMonth);
+                    }
+                    return rewardTransactionRepository.save(transaction)
+                            .thenReturn(accruedRewardCents(transaction, initiativeId));
+                })
+                .reduce(new ReassignmentTotals(), ReassignmentTotals::add)
+                .flatMap(totals -> rewardBatchRepository.updateTotals(
+                        targetBatch.getInitiativeId(),
+                        targetBatch.getId(),
+                        BatchCountersDTO.newBatch()
+                                .incrementInitialAmountCents(totals.accruedRewardCents)
+                                .incrementTrxElaborated(totals.transactions)
+                                .incrementNumberOfTransactions(totals.transactions)
+                                .incrementSuspendedAmountCents(totals.accruedRewardCents)
+                                .incrementTrxSuspended(totals.transactions)
+                ).then(rewardBatchRepository.updateTotals(
+                        sourceBatch.getInitiativeId(),
+                        sourceBatch.getId(),
+                        BatchCountersDTO.newBatch().decrementNumberOfTransactions(totals.transactions)
+                )))
+                .then();
+    }
+
+    @Override
+    public Mono<RewardTransaction> postponeTransaction(
+            RewardTransaction transaction,
+            RewardBatch sourceBatch,
+            RewardBatch targetBatch,
+            BatchCountersDTO sourceCounters,
+            BatchCountersDTO targetCounters
+    ) {
+        transaction.setRewardBatchId(targetBatch.getId());
+        transaction.setRewardBatchInclusionDate(LocalDateTime.now());
+        transaction.setUpdateDate(LocalDateTime.now());
+
+        return rewardBatchRepository.updateTotals(
+                        sourceBatch.getInitiativeId(),
+                        sourceBatch.getId(),
+                        sourceCounters
+                )
+                .then(rewardBatchRepository.updateTotals(
+                        targetBatch.getInitiativeId(),
+                        targetBatch.getId(),
+                        targetCounters
+                ))
+                .then(rewardTransactionRepository.save(transaction));
+    }
+
+    private long accruedRewardCents(RewardTransaction transaction, String initiativeId) {
+        if (transaction.getRewards() == null) {
+            return 0L;
+        }
+        Reward reward = transaction.getRewards().get(initiativeId);
+        return reward == null || reward.getAccruedRewardCents() == null
+                ? 0L
+                : reward.getAccruedRewardCents();
+    }
+
+    private static final class ReassignmentTotals {
+        private long transactions;
+        private long accruedRewardCents;
+
+        private ReassignmentTotals add(long rewardCents) {
+            transactions++;
+            accruedRewardCents += rewardCents;
+            return this;
+        }
+    }
+}

--- a/src/main/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapter.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapter.java
@@ -10,6 +10,7 @@ import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchTransactionM
 import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
 import it.gov.pagopa.idpay.transactions.repository.RewardTransactionRepository;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -108,8 +109,8 @@ public class MongoRewardBatchTransactionMutationAdapter implements RewardBatchTr
             BatchCountersDTO targetCounters
     ) {
         transaction.setRewardBatchId(targetBatch.getId());
-        transaction.setRewardBatchInclusionDate(LocalDateTime.now());
-        transaction.setUpdateDate(LocalDateTime.now());
+        transaction.setRewardBatchInclusionDate(LocalDateTime.now(ZoneId.systemDefault()));
+        transaction.setUpdateDate(LocalDateTime.now(ZoneId.systemDefault()));
 
         return rewardBatchRepository.updateTotals(
                         sourceBatch.getInitiativeId(),

--- a/src/main/java/it/gov/pagopa/idpay/transactions/persistence/port/RewardBatchTransactionMutationPort.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/persistence/port/RewardBatchTransactionMutationPort.java
@@ -1,0 +1,41 @@
+package it.gov.pagopa.idpay.transactions.persistence.port;
+
+import it.gov.pagopa.idpay.transactions.dto.batch.BatchCountersDTO;
+import it.gov.pagopa.idpay.transactions.model.RewardBatch;
+import it.gov.pagopa.idpay.transactions.model.RewardTransaction;
+import reactor.core.publisher.Mono;
+
+public interface RewardBatchTransactionMutationPort {
+
+    Mono<RewardTransaction> persistInvoiceUpdate(RewardTransaction transaction);
+
+    Mono<RewardTransaction> moveUpdatedInvoice(
+            RewardTransaction transaction,
+            RewardBatch sourceBatch,
+            RewardBatch targetBatch,
+            BatchCountersDTO sourceCounters,
+            BatchCountersDTO targetCounters
+    );
+
+    Mono<Void> reverseInvoice(
+            RewardTransaction transaction,
+            String initiativeId,
+            String sourceBatchId,
+            BatchCountersDTO counters
+    );
+
+    Mono<Void> reassignSuspendedTransactions(
+            RewardBatch sourceBatch,
+            RewardBatch targetBatch,
+            String initiativeId,
+            String sourceMonth
+    );
+
+    Mono<RewardTransaction> postponeTransaction(
+            RewardTransaction transaction,
+            RewardBatch sourceBatch,
+            RewardBatch targetBatch,
+            BatchCountersDTO sourceCounters,
+            BatchCountersDTO targetCounters
+    );
+}

--- a/src/main/java/it/gov/pagopa/idpay/transactions/service/PointOfSaleTransactionServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/service/PointOfSaleTransactionServiceImpl.java
@@ -14,6 +14,7 @@ import it.gov.pagopa.idpay.transactions.model.RewardTransaction;
 import it.gov.pagopa.idpay.transactions.notifier.TransactionNotifierService;
 import it.gov.pagopa.idpay.transactions.persistence.port.RewardTransactionSearchPort;
 import it.gov.pagopa.idpay.transactions.persistence.port.InvoiceTransactionLookupPort;
+import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchTransactionMutationPort;
 import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
 import it.gov.pagopa.idpay.transactions.repository.RewardTransactionRepository;
 import it.gov.pagopa.idpay.transactions.service.invoice_lifecycle.InvoiceLifecyclePolicy;
@@ -55,6 +56,7 @@ public class PointOfSaleTransactionServiceImpl implements PointOfSaleTransaction
     private final RewardTransactionRepository rewardTransactionRepository;
     private final RewardTransactionSearchPort rewardTransactionSearchPort;
     private final InvoiceTransactionLookupPort invoiceTransactionLookupPort;
+    private final RewardBatchTransactionMutationPort rewardBatchTransactionMutationPort;
     private final InvoiceStorageClient invoiceStorageClient;
     private final RewardBatchService rewardBatchService;
     private final RewardBatchRepository rewardBatchRepository;
@@ -65,6 +67,7 @@ public class PointOfSaleTransactionServiceImpl implements PointOfSaleTransaction
             UserRestClient userRestClient, RewardTransactionRepository rewardTransactionRepository,
             RewardTransactionSearchPort rewardTransactionSearchPort,
             InvoiceTransactionLookupPort invoiceTransactionLookupPort,
+            RewardBatchTransactionMutationPort rewardBatchTransactionMutationPort,
             InvoiceStorageClient invoiceStorageClient,
             RewardBatchService rewardBatchService,
             RewardBatchRepository rewardBatchRepository,
@@ -74,6 +77,7 @@ public class PointOfSaleTransactionServiceImpl implements PointOfSaleTransaction
         this.rewardTransactionRepository = rewardTransactionRepository;
         this.rewardTransactionSearchPort = rewardTransactionSearchPort;
         this.invoiceTransactionLookupPort = invoiceTransactionLookupPort;
+        this.rewardBatchTransactionMutationPort = rewardBatchTransactionMutationPort;
         this.invoiceStorageClient = invoiceStorageClient;
         this.rewardBatchService = rewardBatchService;
         this.rewardBatchRepository = rewardBatchRepository;
@@ -228,7 +232,7 @@ public class PointOfSaleTransactionServiceImpl implements PointOfSaleTransaction
                             .build());
                     trx.setInvoiceUploadDate(LocalDateTime.now());
                     trx.setUpdateDate(LocalDateTime.now());
-                    return rewardTransactionRepository.save(trx);
+                    return rewardBatchTransactionMutationPort.persistInvoiceUpdate(trx);
                 }));
     }
 
@@ -308,10 +312,13 @@ public class PointOfSaleTransactionServiceImpl implements PointOfSaleTransaction
                     oldTransaction.setRewardBatchId(newBatch.getId());
                     oldTransaction.setUpdateDate(LocalDateTime.now());
 
-                    return rewardTransactionRepository.save(oldTransaction)
-                            .then(rewardBatchRepository.updateTotals(oldBatch.getInitiativeId(), oldBatch.getId(), oldBatchCounter))
-                            .then(rewardBatchRepository.updateTotals(newBatch.getInitiativeId(), newBatch.getId(), newBatchCounter))
-                            .thenReturn(oldTransaction);
+                    return rewardBatchTransactionMutationPort.moveUpdatedInvoice(
+                            oldTransaction,
+                            oldBatch,
+                            newBatch,
+                            oldBatchCounter,
+                            newBatchCounter
+                    );
                 });
     }
 
@@ -388,18 +395,14 @@ public class PointOfSaleTransactionServiceImpl implements PointOfSaleTransaction
 
 
 
-                                    Mono<Void> saveTransactionMono = rewardTransactionRepository.save(rt).then();
-
-                                    Mono<Void> updateBatchTotalsMono =
-                                            oldRewardBatchId != null
-                                                    ? rewardBatchRepository.updateTotals(initiativeId, oldRewardBatchId, counters).then()
-                                                    : Mono.empty();
-
-
                                     Mono<Void> sendToQueueMono = sendReversedInvoicedTransactionNotification(RewardTransactionKafkaMapper.toDto(rt));
 
-                                    return saveTransactionMono
-                                            .then(updateBatchTotalsMono)
+                                    return rewardBatchTransactionMutationPort.reverseInvoice(
+                                                    rt,
+                                                    initiativeId,
+                                                    oldRewardBatchId,
+                                                    counters
+                                            )
                                             .then(sendToQueueMono);
                                 }));
                     });

--- a/src/main/java/it/gov/pagopa/idpay/transactions/service/RewardBatchServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/idpay/transactions/service/RewardBatchServiceImpl.java
@@ -31,6 +31,7 @@ import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchLifecyclePor
 import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchListPort;
 import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchTransactionDecisionPort;
 import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchTransactionReadPort;
+import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchTransactionMutationPort;
 import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
 import it.gov.pagopa.idpay.transactions.repository.RewardTransactionRepository;
 import it.gov.pagopa.idpay.transactions.storage.ApprovedRewardBatchBlobService;
@@ -89,6 +90,7 @@ public class RewardBatchServiceImpl implements RewardBatchService {
     private final RewardTransactionRepository rewardTransactionRepository;
     private final RewardBatchTransactionReadPort rewardBatchTransactionReadPort;
     private final RewardBatchTransactionDecisionPort rewardBatchTransactionDecisionPort;
+    private final RewardBatchTransactionMutationPort rewardBatchTransactionMutationPort;
     private final UserRestClient userRestClient;
     private final ReactiveMongoTemplate reactiveMongoTemplate;
     private final ChecksErrorMapper checksErrorMapper;
@@ -137,6 +139,7 @@ public class RewardBatchServiceImpl implements RewardBatchService {
                                   RewardTransactionRepository rewardTransactionRepository,
                                   RewardBatchTransactionReadPort rewardBatchTransactionReadPort,
                                   RewardBatchTransactionDecisionPort rewardBatchTransactionDecisionPort,
+                                  RewardBatchTransactionMutationPort rewardBatchTransactionMutationPort,
                                   UserRestClient userRestClient,
                                   ApprovedRewardBatchBlobService approvedRewardBatchBlobService,
                                   ReactiveMongoTemplate reactiveMongoTemplate,
@@ -154,6 +157,7 @@ public class RewardBatchServiceImpl implements RewardBatchService {
         this.rewardTransactionRepository = rewardTransactionRepository;
         this.rewardBatchTransactionReadPort = rewardBatchTransactionReadPort;
         this.rewardBatchTransactionDecisionPort = rewardBatchTransactionDecisionPort;
+        this.rewardBatchTransactionMutationPort = rewardBatchTransactionMutationPort;
         this.userRestClient = userRestClient;
         this.approvedRewardBatchBlobService = approvedRewardBatchBlobService;
         this.reactiveMongoTemplate = reactiveMongoTemplate;
@@ -976,39 +980,21 @@ public class RewardBatchServiceImpl implements RewardBatchService {
             return Mono.just(originalBatch);
         }
 
-        return rewardBatchTransactionReadPort
-                .findBatchTransactions(originalBatch.getId(), initiativeId, List.of(RewardBatchTrxStatus.SUSPENDED))
-                .count()
-                .flatMap(countToMove ->
-                        findOrCreateBatch(
-                                originalBatch.getInitiativeId(),
-                                originalBatch.getMerchantId(),
-                                originalBatch.getPosType(),
-                                getTargetMonth(originalBatch.getMonth()),
-                                originalBatch.getBusinessName()
-                        ).flatMap(newBatch ->
-                                updateAndSaveRewardTransactionsSuspended(
-                                        originalBatch.getId(),
-                                        initiativeId,
-                                        newBatch.getId(),
-                                        originalBatch.getMonth()
-                                ).flatMap(totalAccrued -> {
-                                    BatchCountersDTO batchCounters = BatchCountersDTO.newBatch()
-                                            .incrementInitialAmountCents(totalAccrued)
-                                            .incrementTrxElaborated(countToMove)
-                                            .incrementNumberOfTransactions(countToMove)
-                                            .incrementSuspendedAmountCents(totalAccrued)
-                                            .incrementTrxSuspended(countToMove);
-
-                                    return rewardBatchRepository.updateTotals(newBatch.getInitiativeId(), newBatch.getId(), batchCounters)
-                                            .then(rewardBatchRepository.updateTotals(
-                                                    originalBatch.getInitiativeId(),
-                                                    originalBatch.getId(),
-                                                    BatchCountersDTO.newBatch().decrementNumberOfTransactions(countToMove)
-                                            ));
-                                })
+        return findOrCreateBatch(
+                        originalBatch.getInitiativeId(),
+                        originalBatch.getMerchantId(),
+                        originalBatch.getPosType(),
+                        getTargetMonth(originalBatch.getMonth()),
+                        originalBatch.getBusinessName()
+                )
+                .flatMap(newBatch -> rewardBatchTransactionMutationPort
+                        .reassignSuspendedTransactions(
+                                originalBatch,
+                                newBatch,
+                                initiativeId,
+                                originalBatch.getMonth()
                         )
-                );
+                        .thenReturn(originalBatch));
     }
 
     public String addOneMonth(String yearMonthString) {
@@ -1054,34 +1040,6 @@ public class RewardBatchServiceImpl implements RewardBatchService {
                 })
                 .then();
 
-    }
-
-    public Mono<Long> updateAndSaveRewardTransactionsSuspended(String oldBatchId, String initiativeId, String newBatchId, String oldMonth) {
-        List<RewardBatchTrxStatus> statusList = List.of(RewardBatchTrxStatus.SUSPENDED);
-
-        return rewardBatchTransactionReadPort.findBatchTransactions(oldBatchId, initiativeId, statusList)
-                .switchIfEmpty(Flux.defer(() -> {
-                    log.info("No suspended transactions found for the batch {}", Utilities.sanitizeString(oldBatchId));
-                    return Flux.empty();
-                }))
-                .flatMap(rewardTransaction -> {
-                    rewardTransaction.setRewardBatchId(newBatchId);
-                    rewardTransaction.setStatus(SyncTrxStatus.INVOICED.name());
-                    if(rewardTransaction.getRewardBatchLastMonthElaborated() == null) {
-                        rewardTransaction.setRewardBatchLastMonthElaborated(oldMonth);
-                    }
-
-                    Long rewardCents = 0L;
-                    if (rewardTransaction.getRewards() != null &&
-                            rewardTransaction.getRewards().get(initiativeId) != null) {
-                        rewardCents = rewardTransaction.getRewards().get(initiativeId).getAccruedRewardCents();
-                    }
-
-                    return rewardTransactionRepository.save(rewardTransaction)
-                            .thenReturn(rewardCents != null ? rewardCents : 0L);
-                })
-                .reduce(0L, Long::sum)
-                .doOnNext(total -> log.info("Total suspended reward cents from old batch {}: {}", newBatchId, total));
     }
 
     @Override
@@ -1425,9 +1383,13 @@ public class RewardBatchServiceImpl implements RewardBatchService {
         BatchCountersDTO oldBatchCounters = buildOldBatchCounters(trx, accruedRewardCents);
         BatchCountersDTO newBatchCounters = buildNewBatchCounters(trx, accruedRewardCents);
 
-        return rewardBatchRepository.updateTotals(currentBatch.getInitiativeId(), currentBatch.getId(), oldBatchCounters)
-                .then(rewardBatchRepository.updateTotals(nextBatch.getInitiativeId(), nextBatch.getId(), newBatchCounters))
-                .then(Mono.defer(() -> savePostponedTransaction(trx, nextBatch)));
+        return rewardBatchTransactionMutationPort.postponeTransaction(
+                trx,
+                currentBatch,
+                nextBatch,
+                oldBatchCounters,
+                newBatchCounters
+        );
     }
 
     private BatchCountersDTO buildOldBatchCounters(RewardTransaction trx, long accruedRewardCents) {
@@ -1462,14 +1424,6 @@ public class RewardBatchServiceImpl implements RewardBatchService {
 
     private boolean isSuspended(RewardTransaction trx) {
         return RewardBatchTrxStatus.SUSPENDED.equals(trx.getRewardBatchTrxStatus());
-    }
-
-    private Mono<RewardTransaction> savePostponedTransaction(RewardTransaction trx, RewardBatch nextBatch) {
-        trx.setRewardBatchId(nextBatch.getId());
-        trx.setRewardBatchInclusionDate(LocalDateTime.now());
-        trx.setUpdateDate(LocalDateTime.now());
-
-        return rewardTransactionRepository.save(trx);
     }
 
     @Data

--- a/src/test/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -82,7 +83,7 @@ class MongoRewardBatchTransactionMutationAdapterTest {
                 .verifyComplete();
 
         verify(rewardTransactionRepository).save(transaction);
-        verify(rewardBatchRepository, org.mockito.Mockito.never()).updateTotals(any(), any(), any());
+        verify(rewardBatchRepository, never()).updateTotals(any(), any(), any());
     }
 
     @Test
@@ -109,7 +110,7 @@ class MongoRewardBatchTransactionMutationAdapterTest {
                 ))
                 .verifyComplete();
 
-        verify(rewardTransactionRepository, org.mockito.Mockito.never()).save(any());
+        verify(rewardTransactionRepository, never()).save(any());
 
         ArgumentCaptor<BatchCountersDTO> targetCounters = ArgumentCaptor.forClass(BatchCountersDTO.class);
         verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(TARGET_BATCH_ID), targetCounters.capture());

--- a/src/test/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapterTest.java
@@ -86,7 +86,45 @@ class MongoRewardBatchTransactionMutationAdapterTest {
     }
 
     @Test
-    void suspendedReassignmentMovesMembershipAndDerivesCounterDeltas() {
+    void reassignSuspendedTransactions_emptyMovesNoTransactionsAndAppliesZeroCounterDeltas() {
+        MongoRewardBatchTransactionMutationAdapter adapter = adapter();
+        RewardBatch source = batch(SOURCE_BATCH_ID);
+        RewardBatch target = batch(TARGET_BATCH_ID);
+
+        when(rewardTransactionRepository.findByFilter(
+                SOURCE_BATCH_ID,
+                INITIATIVE_ID,
+                List.of(RewardBatchTrxStatus.SUSPENDED)
+        )).thenReturn(Flux.empty());
+        when(rewardBatchRepository.updateTotals(eq(INITIATIVE_ID), eq(TARGET_BATCH_ID), any()))
+                .thenReturn(Mono.just(target));
+        when(rewardBatchRepository.updateTotals(eq(INITIATIVE_ID), eq(SOURCE_BATCH_ID), any()))
+                .thenReturn(Mono.just(source));
+
+        StepVerifier.create(adapter.reassignSuspendedTransactions(
+                        source,
+                        target,
+                        INITIATIVE_ID,
+                        "2025-12"
+                ))
+                .verifyComplete();
+
+        verify(rewardTransactionRepository, org.mockito.Mockito.never()).save(any());
+
+        ArgumentCaptor<BatchCountersDTO> targetCounters = ArgumentCaptor.forClass(BatchCountersDTO.class);
+        verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(TARGET_BATCH_ID), targetCounters.capture());
+        assertEquals(0L, targetCounters.getValue().getInitialAmountCents());
+        assertEquals(0L, targetCounters.getValue().getNumberOfTransactions());
+        assertEquals(0L, targetCounters.getValue().getTrxSuspended());
+        assertEquals(0L, targetCounters.getValue().getTrxElaborated());
+
+        ArgumentCaptor<BatchCountersDTO> sourceCounters = ArgumentCaptor.forClass(BatchCountersDTO.class);
+        verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(SOURCE_BATCH_ID), sourceCounters.capture());
+        assertEquals(0L, sourceCounters.getValue().getNumberOfTransactions());
+    }
+
+    @Test
+    void reassignSuspendedTransactions_movesAndSumsAndSetsLastMonthWhenAbsent() {
         MongoRewardBatchTransactionMutationAdapter adapter = adapter();
         RewardBatch source = batch(SOURCE_BATCH_ID);
         RewardBatch target = batch(TARGET_BATCH_ID);

--- a/src/test/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/idpay/transactions/persistence/mongo/MongoRewardBatchTransactionMutationAdapterTest.java
@@ -1,0 +1,188 @@
+package it.gov.pagopa.idpay.transactions.persistence.mongo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import it.gov.pagopa.idpay.transactions.dto.batch.BatchCountersDTO;
+import it.gov.pagopa.idpay.transactions.enums.RewardBatchTrxStatus;
+import it.gov.pagopa.idpay.transactions.enums.SyncTrxStatus;
+import it.gov.pagopa.idpay.transactions.model.Reward;
+import it.gov.pagopa.idpay.transactions.model.RewardBatch;
+import it.gov.pagopa.idpay.transactions.model.RewardTransaction;
+import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
+import it.gov.pagopa.idpay.transactions.repository.RewardTransactionRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class MongoRewardBatchTransactionMutationAdapterTest {
+
+    private static final String INITIATIVE_ID = "initiative";
+    private static final String SOURCE_BATCH_ID = "source";
+    private static final String TARGET_BATCH_ID = "target";
+
+    @Mock
+    private RewardTransactionRepository rewardTransactionRepository;
+    @Mock
+    private RewardBatchRepository rewardBatchRepository;
+
+    @Test
+    void invoiceMutationsPreserveSaveThenCounterUpdateOrdering() {
+        MongoRewardBatchTransactionMutationAdapter adapter = adapter();
+        RewardTransaction transaction = transaction("transaction", 100L);
+        RewardBatch source = batch(SOURCE_BATCH_ID);
+        RewardBatch target = batch(TARGET_BATCH_ID);
+        BatchCountersDTO sourceCounters = BatchCountersDTO.newBatch().decrementNumberOfTransactions();
+        BatchCountersDTO targetCounters = BatchCountersDTO.newBatch().incrementNumberOfTransactions(1L);
+
+        when(rewardTransactionRepository.save(transaction)).thenReturn(Mono.just(transaction));
+        when(rewardBatchRepository.updateTotals(INITIATIVE_ID, SOURCE_BATCH_ID, sourceCounters))
+                .thenReturn(Mono.just(source));
+        when(rewardBatchRepository.updateTotals(INITIATIVE_ID, TARGET_BATCH_ID, targetCounters))
+                .thenReturn(Mono.just(target));
+
+        StepVerifier.create(adapter.moveUpdatedInvoice(
+                        transaction,
+                        source,
+                        target,
+                        sourceCounters,
+                        targetCounters
+                ))
+                .expectNext(transaction)
+                .verifyComplete();
+
+        InOrder inOrder = inOrder(rewardTransactionRepository, rewardBatchRepository);
+        inOrder.verify(rewardTransactionRepository).save(transaction);
+        inOrder.verify(rewardBatchRepository).updateTotals(INITIATIVE_ID, SOURCE_BATCH_ID, sourceCounters);
+        inOrder.verify(rewardBatchRepository).updateTotals(INITIATIVE_ID, TARGET_BATCH_ID, targetCounters);
+    }
+
+    @Test
+    void reversalPersistsTransactionWithoutCounterUpdateWhenItHasNoBatch() {
+        MongoRewardBatchTransactionMutationAdapter adapter = adapter();
+        RewardTransaction transaction = transaction("transaction", 100L);
+        BatchCountersDTO counters = BatchCountersDTO.newBatch().decrementNumberOfTransactions();
+        when(rewardTransactionRepository.save(transaction)).thenReturn(Mono.just(transaction));
+
+        StepVerifier.create(adapter.reverseInvoice(transaction, INITIATIVE_ID, null, counters))
+                .verifyComplete();
+
+        verify(rewardTransactionRepository).save(transaction);
+        verify(rewardBatchRepository, org.mockito.Mockito.never()).updateTotals(any(), any(), any());
+    }
+
+    @Test
+    void suspendedReassignmentMovesMembershipAndDerivesCounterDeltas() {
+        MongoRewardBatchTransactionMutationAdapter adapter = adapter();
+        RewardBatch source = batch(SOURCE_BATCH_ID);
+        RewardBatch target = batch(TARGET_BATCH_ID);
+        RewardTransaction first = transaction("first", 100L);
+        RewardTransaction second = transaction("second", null);
+        second.setRewardBatchLastMonthElaborated("2025-10");
+
+        when(rewardTransactionRepository.findByFilter(
+                SOURCE_BATCH_ID,
+                INITIATIVE_ID,
+                List.of(RewardBatchTrxStatus.SUSPENDED)
+        )).thenReturn(Flux.just(first, second));
+        when(rewardTransactionRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        when(rewardBatchRepository.updateTotals(eq(INITIATIVE_ID), eq(TARGET_BATCH_ID), any()))
+                .thenReturn(Mono.just(target));
+        when(rewardBatchRepository.updateTotals(eq(INITIATIVE_ID), eq(SOURCE_BATCH_ID), any()))
+                .thenReturn(Mono.just(source));
+
+        StepVerifier.create(adapter.reassignSuspendedTransactions(
+                        source,
+                        target,
+                        INITIATIVE_ID,
+                        "2025-12"
+                ))
+                .verifyComplete();
+
+        assertEquals(TARGET_BATCH_ID, first.getRewardBatchId());
+        assertEquals(SyncTrxStatus.INVOICED.name(), first.getStatus());
+        assertEquals("2025-12", first.getRewardBatchLastMonthElaborated());
+        assertEquals(TARGET_BATCH_ID, second.getRewardBatchId());
+        assertEquals("2025-10", second.getRewardBatchLastMonthElaborated());
+
+        ArgumentCaptor<BatchCountersDTO> targetCounters = ArgumentCaptor.forClass(BatchCountersDTO.class);
+        verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(TARGET_BATCH_ID), targetCounters.capture());
+        assertEquals(100L, targetCounters.getValue().getInitialAmountCents());
+        assertEquals(2L, targetCounters.getValue().getNumberOfTransactions());
+        assertEquals(2L, targetCounters.getValue().getTrxSuspended());
+        assertEquals(2L, targetCounters.getValue().getTrxElaborated());
+
+        ArgumentCaptor<BatchCountersDTO> sourceCounters = ArgumentCaptor.forClass(BatchCountersDTO.class);
+        verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(SOURCE_BATCH_ID), sourceCounters.capture());
+        assertEquals(-2L, sourceCounters.getValue().getNumberOfTransactions());
+    }
+
+    @Test
+    void postponementUpdatesCountersBeforePersistingNewMembership() {
+        MongoRewardBatchTransactionMutationAdapter adapter = adapter();
+        RewardTransaction transaction = transaction("transaction", 100L);
+        RewardBatch source = batch(SOURCE_BATCH_ID);
+        RewardBatch target = batch(TARGET_BATCH_ID);
+        BatchCountersDTO sourceCounters = BatchCountersDTO.newBatch().decrementNumberOfTransactions();
+        BatchCountersDTO targetCounters = BatchCountersDTO.newBatch().incrementNumberOfTransactions(1L);
+
+        when(rewardBatchRepository.updateTotals(INITIATIVE_ID, SOURCE_BATCH_ID, sourceCounters))
+                .thenReturn(Mono.just(source));
+        when(rewardBatchRepository.updateTotals(INITIATIVE_ID, TARGET_BATCH_ID, targetCounters))
+                .thenReturn(Mono.just(target));
+        when(rewardTransactionRepository.save(transaction)).thenReturn(Mono.just(transaction));
+
+        StepVerifier.create(adapter.postponeTransaction(
+                        transaction,
+                        source,
+                        target,
+                        sourceCounters,
+                        targetCounters
+                ))
+                .expectNext(transaction)
+                .verifyComplete();
+
+        assertEquals(TARGET_BATCH_ID, transaction.getRewardBatchId());
+        assertNotNull(transaction.getRewardBatchInclusionDate());
+
+        InOrder inOrder = inOrder(rewardTransactionRepository, rewardBatchRepository);
+        inOrder.verify(rewardBatchRepository).updateTotals(INITIATIVE_ID, SOURCE_BATCH_ID, sourceCounters);
+        inOrder.verify(rewardBatchRepository).updateTotals(INITIATIVE_ID, TARGET_BATCH_ID, targetCounters);
+        inOrder.verify(rewardTransactionRepository).save(transaction);
+    }
+
+    private MongoRewardBatchTransactionMutationAdapter adapter() {
+        return new MongoRewardBatchTransactionMutationAdapter(
+                rewardTransactionRepository,
+                rewardBatchRepository
+        );
+    }
+
+    private RewardBatch batch(String id) {
+        return RewardBatch.builder().id(id).initiativeId(INITIATIVE_ID).build();
+    }
+
+    private RewardTransaction transaction(String id, Long accruedRewardCents) {
+        return RewardTransaction.builder()
+                .id(id)
+                .rewards(Map.of(
+                        INITIATIVE_ID,
+                        Reward.builder().accruedRewardCents(accruedRewardCents).build()
+                ))
+                .build();
+    }
+}

--- a/src/test/java/it/gov/pagopa/idpay/transactions/service/PointOfSaleTransactionServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/idpay/transactions/service/PointOfSaleTransactionServiceImplTest.java
@@ -19,6 +19,7 @@ import it.gov.pagopa.idpay.transactions.model.Reward;
 import it.gov.pagopa.idpay.transactions.model.RewardBatch;
 import it.gov.pagopa.idpay.transactions.model.RewardTransaction;
 import it.gov.pagopa.idpay.transactions.persistence.mongo.MongoRewardTransactionAdapter;
+import it.gov.pagopa.idpay.transactions.persistence.mongo.MongoRewardBatchTransactionMutationAdapter;
 import it.gov.pagopa.idpay.transactions.notifier.TransactionNotifierService;
 import it.gov.pagopa.idpay.transactions.persistence.port.RewardTransactionSearchPort;
 import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
@@ -97,6 +98,10 @@ class PointOfSaleTransactionServiceImplTest {
                 rewardTransactionRepository,
                 rewardTransactionSearchPort,
                 new MongoRewardTransactionAdapter(rewardTransactionRepository),
+                new MongoRewardBatchTransactionMutationAdapter(
+                        rewardTransactionRepository,
+                        rewardBatchRepository
+                ),
                 invoiceStorageClient,
                 rewardBatchService,
                 rewardBatchRepository,

--- a/src/test/java/it/gov/pagopa/idpay/transactions/service/RewardBatchServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/idpay/transactions/service/RewardBatchServiceImplTest.java
@@ -33,6 +33,7 @@ import it.gov.pagopa.idpay.transactions.persistence.port.RewardBatchListPort;
 import it.gov.pagopa.idpay.transactions.persistence.mongo.MongoMerchantRewardBatchLookupAdapter;
 import it.gov.pagopa.idpay.transactions.persistence.mongo.MongoRewardBatchLifecycleAdapter;
 import it.gov.pagopa.idpay.transactions.persistence.mongo.MongoRewardTransactionAdapter;
+import it.gov.pagopa.idpay.transactions.persistence.mongo.MongoRewardBatchTransactionMutationAdapter;
 import it.gov.pagopa.idpay.transactions.repository.RewardBatchRepository;
 import it.gov.pagopa.idpay.transactions.repository.RewardTransactionRepository;
 import it.gov.pagopa.idpay.transactions.storage.ApprovedRewardBatchBlobService;
@@ -117,6 +118,10 @@ class RewardBatchServiceImplTest {
                 rewardTransactionRepository,
                 new MongoRewardTransactionAdapter(rewardTransactionRepository),
                 new MongoRewardTransactionAdapter(rewardTransactionRepository),
+                new MongoRewardBatchTransactionMutationAdapter(
+                        rewardTransactionRepository,
+                        rewardBatchRepository
+                ),
                 userRestClient,
                 approvedRewardBatchBlobService,
                 reactiveMongoTemplate,
@@ -1324,50 +1329,6 @@ class RewardBatchServiceImplTest {
     }
 
     @Test
-    void updateAndSaveRewardTransactionsSuspended_empty_returnsZero() {
-        when(rewardTransactionRepository.findByFilter(eq(BATCH_ID), eq(INITIATIVE_ID), anyList()))
-                .thenReturn(Flux.empty());
-
-        StepVerifier.create(service.updateAndSaveRewardTransactionsSuspended(BATCH_ID, INITIATIVE_ID, BATCH_ID_2, "2025-12"))
-                .expectNext(0L)
-                .verifyComplete();
-    }
-
-    @Test
-    void updateAndSaveRewardTransactionsSuspended_movesAndSums_andSetsLastMonthIfNull() {
-        RewardTransaction t1 = RewardTransaction.builder()
-                .id("T1")
-                .rewardBatchTrxStatus(RewardBatchTrxStatus.SUSPENDED)
-                .rewardBatchId(BATCH_ID)
-                .rewardBatchLastMonthElaborated(null)
-                .rewards(Map.of(INITIATIVE_ID, Reward.builder().accruedRewardCents(100L).build()))
-                .build();
-
-        RewardTransaction t2 = RewardTransaction.builder()
-                .id("T2")
-                .rewardBatchTrxStatus(RewardBatchTrxStatus.SUSPENDED)
-                .rewardBatchId(BATCH_ID)
-                .rewardBatchLastMonthElaborated("2025-11")
-                .rewards(null)
-                .build();
-
-        when(rewardTransactionRepository.findByFilter(eq(BATCH_ID), eq(INITIATIVE_ID), anyList()))
-                .thenReturn(Flux.just(t1, t2));
-        when(rewardTransactionRepository.save(any())).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
-
-        StepVerifier.create(service.updateAndSaveRewardTransactionsSuspended(BATCH_ID, INITIATIVE_ID, BATCH_ID_2, "2025-12"))
-                .expectNext(100L)
-                .verifyComplete();
-
-        assertEquals(BATCH_ID_2, t1.getRewardBatchId());
-        assertEquals(SyncTrxStatus.INVOICED.name(), t1.getStatus());
-        assertEquals("2025-12", t1.getRewardBatchLastMonthElaborated());
-        assertEquals(BATCH_ID_2, t2.getRewardBatchId());
-        assertEquals(SyncTrxStatus.INVOICED.name(), t2.getStatus());
-        assertEquals("2025-11", t2.getRewardBatchLastMonthElaborated());
-    }
-
-    @Test
     void validateRewardBatch_notFound() {
         when(rewardBatchRepository.findById(BATCH_ID)).thenReturn(Mono.empty());
 
@@ -2374,9 +2335,6 @@ class RewardBatchServiceImplTest {
         doReturn(Mono.just(targetBatch)).when(serviceSpy)
                 .findOrCreateBatch(INITIATIVE_ID, MERCHANT_ID, PHYSICAL, targetMonth, BUSINESS_NAME);
 
-        doReturn(Mono.just(300L)).when(serviceSpy)
-                .updateAndSaveRewardTransactionsSuspended(BATCH_ID, INITIATIVE_ID, BATCH_ID_2, originalMonth);
-
         when(rewardBatchRepository.updateTotals(eq(INITIATIVE_ID), eq(BATCH_ID_2), any(BatchCountersDTO.class)))
                 .thenReturn(Mono.just(targetBatch));
 
@@ -2388,6 +2346,7 @@ class RewardBatchServiceImplTest {
                 INITIATIVE_ID,
                 List.of(RewardBatchTrxStatus.SUSPENDED)
         )).thenReturn(Flux.just(new RewardTransaction()));
+        when(rewardTransactionRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
 
         Mono<RewardBatch> result = ReflectionTestUtils.invokeMethod(
                 serviceSpy,
@@ -2403,7 +2362,6 @@ class RewardBatchServiceImplTest {
                 .verifyComplete();
 
         verify(serviceSpy).findOrCreateBatch(INITIATIVE_ID, MERCHANT_ID, PHYSICAL, targetMonth, BUSINESS_NAME);
-        verify(serviceSpy).updateAndSaveRewardTransactionsSuspended(BATCH_ID, INITIATIVE_ID, BATCH_ID_2, originalMonth);
         verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(BATCH_ID_2), any(BatchCountersDTO.class));
     }
 
@@ -2432,9 +2390,6 @@ class RewardBatchServiceImplTest {
         doReturn(Mono.just(targetBatch)).when(serviceSpy)
                 .findOrCreateBatch(INITIATIVE_ID, MERCHANT_ID, PHYSICAL, originalMonth, BUSINESS_NAME);
 
-        doReturn(Mono.just(100L)).when(serviceSpy)
-                .updateAndSaveRewardTransactionsSuspended(BATCH_ID, INITIATIVE_ID, BATCH_ID_2, originalMonth);
-
         when(rewardBatchRepository.updateTotals(eq(INITIATIVE_ID), eq(BATCH_ID_2), any(BatchCountersDTO.class)))
                 .thenReturn(Mono.just(targetBatch));
 
@@ -2446,6 +2401,7 @@ class RewardBatchServiceImplTest {
                 INITIATIVE_ID,
                 List.of(RewardBatchTrxStatus.SUSPENDED)
         )).thenReturn(Flux.just(new RewardTransaction()));
+        when(rewardTransactionRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
 
         Mono<RewardBatch> result = ReflectionTestUtils.invokeMethod(
                 serviceSpy,
@@ -2461,7 +2417,6 @@ class RewardBatchServiceImplTest {
                 .verifyComplete();
 
         verify(serviceSpy).findOrCreateBatch(INITIATIVE_ID, MERCHANT_ID, PHYSICAL, originalMonth, BUSINESS_NAME);
-        verify(serviceSpy).updateAndSaveRewardTransactionsSuspended(BATCH_ID, INITIATIVE_ID, BATCH_ID_2, originalMonth);
         verify(rewardBatchRepository).updateTotals(eq(INITIATIVE_ID), eq(BATCH_ID_2), any(BatchCountersDTO.class));
     }
 


### PR DESCRIPTION
## Summary
- introduce explicit persistence commands for invoice updates/reversals, suspended reassignments, and merchant postponements
- preserve existing Mongo mutation ordering and counter behavior through a dedicated adapter
- characterize the command effects and update the affected service tests

## Validation
- `mvn -q test`